### PR TITLE
Give metrics unique names

### DIFF
--- a/cf_templates/eb_bridgepf.yml
+++ b/cf_templates/eb_bridgepf.yml
@@ -730,7 +730,10 @@ Resources:
         -
           MetricValue: "1"
           MetricNamespace: "LogMetrics/Errors"
-          MetricName: "ErrorCount"
+          MetricName: !Join
+            - '-'
+            - - !Ref 'AWS::StackName'
+              - RequestErrorCount
   AWSCWRequestErrorAlarm:
     Type: "AWS::CloudWatch::Alarm"
     Properties:
@@ -739,7 +742,10 @@ Resources:
         - !Ref AWSSNSTopic
       ComparisonOperator: GreaterThanOrEqualToThreshold
       EvaluationPeriods: 1
-      MetricName: ErrorCount
+      MetricName: !Join
+        - '-'
+        - - !Ref 'AWS::StackName'
+          - RequestErrorCount
       Namespace: LogMetrics/Errors
       Period: 3600
       Statistic: Sum
@@ -758,7 +764,10 @@ Resources:
         -
           MetricValue: "1"
           MetricNamespace: "LogMetrics/LostMessages"
-          MetricName: "LostMessageCount"
+          MetricName: !Join
+            - '-'
+            - - !Ref 'AWS::StackName'
+              - LostMessageCount
   AWSCWRequestLostMessageAlarm:
     Type: "AWS::CloudWatch::Alarm"
     Properties:
@@ -767,7 +776,10 @@ Resources:
         - !Ref AWSSNSTopic
       ComparisonOperator: GreaterThanOrEqualToThreshold
       EvaluationPeriods: 1
-      MetricName: LostMessageCount
+      MetricName: !Join
+        - '-'
+        - - !Ref 'AWS::StackName'
+          - LostMessageCount
       Namespace: LogMetrics/LostMessages
       Period: 3600
       Statistic: Sum
@@ -786,7 +798,10 @@ Resources:
         -
           MetricValue: "1"
           MetricNamespace: "LogMetrics/Warnings"
-          MetricName: "WarningCount"
+          MetricName: !Join
+            - '-'
+            - - !Ref 'AWS::StackName'
+              - RequestWarningCount
   AWSCWRequestWarningAlarm:
     Type: "AWS::CloudWatch::Alarm"
     Properties:
@@ -795,7 +810,10 @@ Resources:
         - !Ref AWSSNSTopic
       ComparisonOperator: GreaterThanOrEqualToThreshold
       EvaluationPeriods: 1
-      MetricName: WarningCount
+      MetricName: !Join
+        - '-'
+        - - !Ref 'AWS::StackName'
+          - RequestWarningCount
       Namespace: LogMetrics/Warnings
       Period: 3600
       Statistic: Sum
@@ -814,7 +832,10 @@ Resources:
         -
           MetricValue: "1"
           MetricNamespace: "LogMetrics/Exceptions"
-          MetricName: "ThroughputExceededExceptionCount"
+          MetricName: !Join
+            - '-'
+            - - !Ref 'AWS::StackName'
+              - ThroughputExceededExceptionCount
   AWSCWThroughputExceptionAlarm:
     Type: "AWS::CloudWatch::Alarm"
     Properties:
@@ -823,7 +844,10 @@ Resources:
         - !Ref AWSSNSTopic
       ComparisonOperator: GreaterThanOrEqualToThreshold
       EvaluationPeriods: 1
-      MetricName: ThroughputExceededExceptionCount
+      MetricName: !Join
+        - '-'
+        - - !Ref 'AWS::StackName'
+          - ThroughputExceededExceptionCount
       Namespace: LogMetrics/Exceptions
       Period: 3600
       Statistic: Sum
@@ -842,7 +866,10 @@ Resources:
         -
           MetricValue: "1"
           MetricNamespace: "LogMetrics/400s"
-          MetricName: "400Count"
+          MetricName: !Join
+            - '-'
+            - - !Ref 'AWS::StackName'
+              - 400Count
   AWSCW400Alarm:
     Type: "AWS::CloudWatch::Alarm"
     Properties:
@@ -851,7 +878,10 @@ Resources:
         - !Ref AWSSNSTopic
       ComparisonOperator: GreaterThanOrEqualToThreshold
       EvaluationPeriods: 1
-      MetricName: 400Count
+      MetricName: !Join
+        - '-'
+        - - !Ref 'AWS::StackName'
+          - 400Count
       Namespace: LogMetrics/400s
       Period: 3600
       Statistic: Sum
@@ -870,7 +900,10 @@ Resources:
         -
           MetricValue: "1"
           MetricNamespace: "LogMetrics/403s"
-          MetricName: "403Count"
+          MetricName: !Join
+            - '-'
+            - - !Ref 'AWS::StackName'
+              - 403Count
   AWSCW403Alarm:
     Type: "AWS::CloudWatch::Alarm"
     Properties:
@@ -879,7 +912,10 @@ Resources:
         - !Ref AWSSNSTopic
       ComparisonOperator: GreaterThanOrEqualToThreshold
       EvaluationPeriods: 1
-      MetricName: 403Count
+      MetricName: !Join
+        - '-'
+        - - !Ref 'AWS::StackName'
+          - 403Count
       Namespace: LogMetrics/403s
       Period: 3600
       Statistic: Sum
@@ -898,7 +934,10 @@ Resources:
         -
           MetricValue: "1"
           MetricNamespace: "LogMetrics/409s"
-          MetricName: "409Count"
+          MetricName: !Join
+            - '-'
+            - - !Ref 'AWS::StackName'
+              - 409Count
   AWSCW409Alarm:
     Type: "AWS::CloudWatch::Alarm"
     Properties:
@@ -907,7 +946,10 @@ Resources:
         - !Ref AWSSNSTopic
       ComparisonOperator: GreaterThanOrEqualToThreshold
       EvaluationPeriods: 1
-      MetricName: 409Count
+      MetricName: !Join
+        - '-'
+        - - !Ref 'AWS::StackName'
+          - 409Count
       Namespace: LogMetrics/409s
       Period: 3600
       Statistic: Sum
@@ -926,7 +968,10 @@ Resources:
         -
           MetricValue: "1"
           MetricNamespace: "LogMetrics/412s"
-          MetricName: "412Count"
+          MetricName: !Join
+            - '-'
+            - - !Ref 'AWS::StackName'
+              - 412Count
   AWSCW412Alarm:
     Type: "AWS::CloudWatch::Alarm"
     Properties:
@@ -935,7 +980,10 @@ Resources:
         - !Ref AWSSNSTopic
       ComparisonOperator: GreaterThanOrEqualToThreshold
       EvaluationPeriods: 1
-      MetricName: 412Count
+      MetricName: !Join
+        - '-'
+        - - !Ref 'AWS::StackName'
+          - 412Count
       Namespace: LogMetrics/412s
       Period: 3600
       Statistic: Sum


### PR DESCRIPTION
Give metrics unique names so that each alarm can be associated
with a specific metric.

Fixes BRIDGE-1918