### PR TITLE
Add the bridgepf url to CF ouput

### DIFF
--- a/cf_templates/eb_bridgepf.yml
+++ b/cf_templates/eb_bridgepf.yml
@@ -66,6 +66,15 @@ Outputs:
     Value: !GetAtt AWSIAMUserAccessKey.SecretAccessKey
     Export:
       Name: !Sub '${AWS::StackName}-SecretAccessKeyId'
+  AWSR53RecordSet:
+    Value: !Join
+      - ''
+      - - 'https://'
+        - !Ref DNSHostname
+        - .
+        - !Ref DNSDomain
+    Export:
+      Name: !Sub '${AWS::StackName}-AWSR53RecordSet'
   AWSS3AttachmentBucket:
     Value: !Ref AWSS3AttachmentBucket
     Export:

--- a/cf_templates/eb_bridgepf.yml
+++ b/cf_templates/eb_bridgepf.yml
@@ -66,15 +66,6 @@ Outputs:
     Value: !GetAtt AWSIAMUserAccessKey.SecretAccessKey
     Export:
       Name: !Sub '${AWS::StackName}-SecretAccessKeyId'
-  AWSR53RecordSet:
-    Value: !Join
-      - ''
-      - - 'https://'
-        - !Ref DNSHostname
-        - .
-        - !Ref DNSDomain
-    Export:
-      Name: !Sub '${AWS::StackName}-AWSR53RecordSet'
   AWSS3AttachmentBucket:
     Value: !Ref AWSS3AttachmentBucket
     Export:
@@ -95,6 +86,15 @@ Outputs:
     Value: !Ref AWSS3UploadCmsPrivBucket
     Export:
       Name: !Sub '${AWS::StackName}-UploadCmsPrivBucket'
+  BridgePFUrl:
+    Value: !Join
+      - ''
+      - - 'https://'
+        - !Ref DNSHostname
+        - .
+        - !Ref DNSDomain
+    Export:
+      Name: !Sub '${AWS::StackName}-BridgePFUrl'
 Mappings:
   AWSLoadbalancerAccount:
     us-east-1:

--- a/cf_templates/eb_bridgepf.yml
+++ b/cf_templates/eb_bridgepf.yml
@@ -24,6 +24,15 @@
 Description: AWS Elastic Beanstalk Application
 AWSTemplateFormatVersion: 2010-09-09
 Outputs:
+  AppPublicEndpoint:
+    Value: !Join
+      - ''
+      - - 'https://'
+        - !Ref DNSHostname
+        - .
+        - !Ref DNSDomain
+    Export:
+      Name: !Sub '${AWS::StackName}-AppPublicEndpoint'
   AWSS3AppDeployBucket:
     Value: !Ref AWSS3AppDeployBucket
     Export:
@@ -86,15 +95,6 @@ Outputs:
     Value: !Ref AWSS3UploadCmsPrivBucket
     Export:
       Name: !Sub '${AWS::StackName}-UploadCmsPrivBucket'
-  BridgePFUrl:
-    Value: !Join
-      - ''
-      - - 'https://'
-        - !Ref DNSHostname
-        - .
-        - !Ref DNSDomain
-    Export:
-      Name: !Sub '${AWS::StackName}-BridgePFUrl'
 Mappings:
   AWSLoadbalancerAccount:
     us-east-1:


### PR DESCRIPTION
Adding the bridgepf url to CF output so that the param value can be
accessed across stacks.