### PR TITLE
Explicitly disable xray service

### DIFF
--- a/cf_templates/eb_bridgepf.yml
+++ b/cf_templates/eb_bridgepf.yml
@@ -392,6 +392,9 @@ Resources:
         - Namespace: 'aws:elasticbeanstalk:hostmanager'
           OptionName: LogPublicationControl
           Value: true
+        - Namespace: 'aws:elasticbeanstalk:xray'
+          OptionName: XRayEnabled
+          Value: false
         - Namespace: 'aws:elb:loadbalancer'
           OptionName: LoadBalancerHTTPPort
           Value: 80


### PR DESCRIPTION
I've noticed that the AWS X-Ray service, which is supposed to
be disabled by default, is enabled upon initial stack creation on
another AWS account.  This will hopefully make sure that the
service is disabled.