### PR TITLE
Match DependsOn setting with the property

### DIFF
--- a/cf_templates/eb_bridgepf.yml
+++ b/cf_templates/eb_bridgepf.yml
@@ -1030,7 +1030,7 @@ Resources:
     Type: 'AWS::ElastiCache::SecurityGroupIngress'
     DependsOn:
       - AWSECacheSecurityGroup
-      - AWSLBSecurityGroup
+      - AWSEC2SecurityGroup
     Properties:
       CacheSecurityGroupName: !Ref AWSECacheSecurityGroup
       EC2SecurityGroupName: !Join


### PR DESCRIPTION
The elasticache property is set correctly but the dependency setting
didn't match up. Elasticache depends on EC2 not LB.