### PR TITLE
Add cloudwatch metric and alarm

### DIFF
--- a/cf_templates/eb_bridgepf.yml
+++ b/cf_templates/eb_bridgepf.yml
@@ -766,6 +766,36 @@ Resources:
       Period: 3600
       Statistic: Sum
       Threshold: 10
+  AWSCWWebErrorMetricFilter:
+    Type: "AWS::Logs::MetricFilter"
+    DependsOn: AWSLogsLogGroupWebError
+    Properties:
+      LogGroupName: !Ref AWSLogsLogGroupWebError
+      FilterPattern: 'Error'
+      MetricTransformations:
+        -
+          MetricValue: "1"
+          MetricNamespace: "LogMetrics/Errors"
+          MetricName: !Join
+            - '-'
+            - - !Ref 'AWS::StackName'
+              - WebErrorCount
+  AWSCWWebErrorAlarm:
+    Type: "AWS::CloudWatch::Alarm"
+    Properties:
+      ActionsEnabled: true
+      AlarmActions:
+        - !Ref AWSSNSTopic
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      EvaluationPeriods: 1
+      MetricName: !Join
+        - '-'
+        - - !Ref 'AWS::StackName'
+          - WebErrorCount
+      Namespace: LogMetrics/Errors
+      Period: 3600
+      Statistic: Sum
+      Threshold: 1
   AWSCWLostMessageMetricFilter:
     Type: "AWS::Logs::MetricFilter"
     DependsOn: AWSLogsLogGroup


### PR DESCRIPTION
Add a cloudwatch metric and alarm to detect any 'Error' in web-1.error.log
This would detect error messages from things like jedis..

com.google.inject.CreationException: Unable to create injector, see the following errors:
1) An exception was caught and reported. Message: Error creating bean with name
'defaultStudyBootstrapper': Invocation of init method failed; nested exception is
org.sagebionetworks.bridge.exceptions.BridgeServiceException:
redis.clients.jedis.exceptions.JedisConnectionException: Could not get a resource from
the pool at com.google.inject.util.Modules$OverrideModule.configure(Modules.java:177)
1 error at com.google.inject.internal.Errors.throwCreationExceptionIfErrorsExist(Errors.java:466)
at com.google.inject.internal.InternalInjectorCreator.initializeStatically(InternalInjectorCreator.java:155)
at com.google.inject.internal.InternalInjectorCreator.build(InternalInjectorCreator.java:107)
at com.google.inject.Guice.createInjector(Guice.java:96)
at com.google.inject.Guice.createInjector(Guice.java:73)
at com.google.inject.Guice.createInjector(Guice.java:62)
at play.api.inject.guice.GuiceBuilder.injector(GuiceInjectorBuilder.scala:126)
at play.api.inject.guice.GuiceApplicationBuilder.build(GuiceApplicationBuilder.scala:93)
at play.api.inject.guice.GuiceApplicationLoader.load(GuiceApplicationLoader.scala:21)
at play.core.server.ProdServerStart$.start(ProdServerStart.scala:52)
at play.core.server.ProdServerStart$.main(ProdServerStart.scala:27)
at play.core.server.ProdServerStart.main(ProdServerStart.scala)
..
..