### PR TITLE
Configure enhanced health reporting for environments

### DIFF
--- a/cf_templates/eb_bridgepf.yml
+++ b/cf_templates/eb_bridgepf.yml
@@ -141,6 +141,9 @@ Parameters:
     Description: The AWS account's default VPC id
     Type: String
     Default: param_place_holder
+  AwsEbHealthReportingSystem:
+    Type: String
+    Default: param_place_holder
   AwsEbNotificationEndpoint:
     Type: String
     Description: Email address for AWS EB notifications
@@ -399,6 +402,9 @@ Resources:
         - Namespace: 'aws:elasticbeanstalk:environment:process:default'
           OptionName: HealthCheckPath
           Value: !Ref AppHealthcheckUrl
+        - Namespace: 'aws:elasticbeanstalk:healthreporting:system'
+          OptionName: SystemType
+          Value: !Ref AwsEbHealthReportingSystem
         - Namespace: 'aws:elasticbeanstalk:sns:topics'
           OptionName: Notification Endpoint
           Value: !Ref AwsEbNotificationEndpoint

--- a/update_cf_stack.sh
+++ b/update_cf_stack.sh
@@ -37,6 +37,7 @@ ParameterKey=AuthProvider,ParameterValue=mysql \
 ParameterKey=AwsAutoScalingMaxSize,ParameterValue=$AwsAutoScalingMaxSize \
 ParameterKey=AwsAutoScalingMinSize,ParameterValue=$AwsAutoScalingMinSize \
 ParameterKey=AwsDefaultVpcId,ParameterValue=$AwsDefaultVpcId \
+ParameterKey=AwsEbHealthReportingSystem,ParameterValue=enhanced \
 ParameterKey=AwsEbNotificationEndpoint,ParameterValue=$AwsEbNotificationEndpoint \
 ParameterKey=AwsKey,ParameterValue=$AwsKey \
 ParameterKey=AwsKeyUpload,ParameterValue=$AwsKeyUpload \


### PR DESCRIPTION
AWS has an enhanced health reporting feature[1] that sends additional
environment health info to cloudwatch logs.  Enabled this feature
with the default EnvironmentHealth metric for all environments.

[1] https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/health-enhanced.html