### PR TITLE
BRIDGE-1943: Disable EB notifications

### DIFF
--- a/cf_templates/eb_bridgepf.yml
+++ b/cf_templates/eb_bridgepf.yml
@@ -415,9 +415,6 @@ Resources:
         - Namespace: 'aws:elasticbeanstalk:healthreporting:system'
           OptionName: SystemType
           Value: !Ref AwsEbHealthReportingSystem
-        - Namespace: 'aws:elasticbeanstalk:sns:topics'
-          OptionName: Notification Endpoint
-          Value: !Ref AwsEbNotificationEndpoint
         - Namespace: 'aws:elasticbeanstalk:hostmanager'
           OptionName: LogPublicationControl
           Value: true


### PR DESCRIPTION
We only want elastic beanstalk notifications on certains warning/error
events however since EB does not allow filtering events we are
getting lots of noisy non-actionable notifications.

Disable EB notifications altogether.  The way to get notificatios
on specific events in AWS is to send the events to cloudwatch and then
setup cloudwatch notifications.