### PR TITLE
BRIDGE-1943: re-enable EB notifications

### DIFF
--- a/cf_templates/eb_bridgepf.yml
+++ b/cf_templates/eb_bridgepf.yml
@@ -415,6 +415,9 @@ Resources:
         - Namespace: 'aws:elasticbeanstalk:healthreporting:system'
           OptionName: SystemType
           Value: !Ref AwsEbHealthReportingSystem
+        - Namespace: 'aws:elasticbeanstalk:sns:topics'
+          OptionName: Notification Endpoint
+          Value: !Ref AwsSnsNotificationEndpoint
         - Namespace: 'aws:elasticbeanstalk:hostmanager'
           OptionName: LogPublicationControl
           Value: true


### PR DESCRIPTION
EB notifications were disabled in PR https://github.com/Sage-Bionetworks/BridgePF-infra/pull/24
because EB events were too noisy due to 4XX and instance downgrade warnings.

A work around to ignore 4XX error was implemented in PR https://github.com/Sage-Bionetworks/BridgePF/pull/1552

Instance downgrade warnings does not occur when deployment is set to immutable, done in change https://github.com/Sage-Bionetworks/BridgePF-infra/pull/33

Re-enable EB alarms again so that we can get the other EB health metric notifications[1].

[1] https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/environments-health-enhanced-notifications.html