### PR TITLE
Set EB to use immutable deployments

### DIFF
--- a/cf_templates/eb_bridgepf.yml
+++ b/cf_templates/eb_bridgepf.yml
@@ -402,7 +402,7 @@ Resources:
           Value: '90'
         - Namespace: 'aws:elasticbeanstalk:command'
           OptionName: DeploymentPolicy
-          Value: 'RollingWithAdditionalBatch'
+          Value: 'Immutable'
         - Namespace: 'aws:elasticbeanstalk:environment'
           OptionName: ServiceRole
           Value: !Ref AWSIAMServiceRole


### PR DESCRIPTION
Seeing EB enhanced health monitor event "Environment health has
transitioned from Info to Degraded." during normal application
deployments.  This seems to be happnening when EB deployment is
setup to use "Rolling with additional batch".  It doesn't happen
when EB is set to use "Immutable" deployments.  Immutable seems
to be the more robust option.

[1] https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/environmentmgmt-updates-immutable.html