### PR TITLE
Revert "BRIDGE-1943: re-enable EB notifications"

### DIFF
--- a/cf_templates/eb_bridgepf.yml
+++ b/cf_templates/eb_bridgepf.yml
@@ -415,9 +415,6 @@ Resources:
         - Namespace: 'aws:elasticbeanstalk:healthreporting:system'
           OptionName: SystemType
           Value: !Ref AwsEbHealthReportingSystem
-        - Namespace: 'aws:elasticbeanstalk:sns:topics'
-          OptionName: Notification Endpoint
-          Value: !Ref AwsSnsNotificationEndpoint
         - Namespace: 'aws:elasticbeanstalk:hostmanager'
           OptionName: LogPublicationControl
           Value: true


### PR DESCRIPTION
This reverts commit f98e2584280a46c4db7f57205e77159c56b42368.

EB notifications are still way too noisy and there doesn't seem
to be a way to configure the noise level.  On deployments it's
sending notifications like these..

"Environment health has transitioned from Ok to Info. Application
update in progress on 1 instance. 0 out of 1 instance"

"Environment health has transitioned from Info to Ok. Configuration
update completed 60 seconds ago and took 8 minutes."