### PR TITLE
Update rolling update deployments

### DIFF
--- a/cf_templates/eb_bridgepf.yml
+++ b/cf_templates/eb_bridgepf.yml
@@ -387,7 +387,7 @@ Resources:
           Value: true
         - Namespace: 'aws:autoscaling:updatepolicy:rollingupdate'
           OptionName: RollingUpdateType
-          Value: 'Health'
+          Value: 'Immutable'
         - Namespace: 'aws:elasticbeanstalk:application'
           OptionName: Application Healthcheck URL
           Value: !Ref AppHealthcheckUrl


### PR DESCRIPTION
Got an error message on deployment today..

"To enable immutable config and application deployments together,
you must set both the DeploymentPolicy option
(aws:elasticbeanstalk:command namespace) and the RollingUpdateType
option (aws:autoscaling:updatepolicy:rollingupdate namespace) to Immutable.

Looks like we need to set Rolling update config to immutable as well.