### PR TITLE
Setup EnvironmentHealth alarm

### DIFF
--- a/cf_templates/eb_bridgepf.yml
+++ b/cf_templates/eb_bridgepf.yml
@@ -1069,6 +1069,19 @@ Resources:
       Period: 900
       Statistic: Average
       Threshold: 80
+  AWSCWEnvironmentHealthAlarm:
+    Type: "AWS::CloudWatch::Alarm"
+    Properties:
+      ActionsEnabled: true
+      AlarmActions:
+        - !Ref AWSSNSTopic
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      EvaluationPeriods: 1
+      MetricName: EnvironmentHealth
+      Namespace: AWS/ElasticBeanstalk
+      Period: 900
+      Statistic: Maximum
+      Threshold: 25
   AWSLBSecurityGroup:
     Type: 'AWS::EC2::SecurityGroup'
     Properties:
@@ -1206,6 +1219,15 @@ Resources:
           - >-
             "view": "timeSeries", "stacked": true, "period":300,
             "stat":"Average", "region":"us-east-1", "title":"InstanceHealth"}},
+          - >-
+            {"type":"metric", "x":0, "y":0, "width":12, "height":6,
+            "properties":{"metrics":[[ "AWS/ElasticBeanstalk", "EnvironmentHealth",
+            "EnvironmentName","
+          - !Ref AWS::StackName
+          - '", {"stat": "Maximum"}]],'
+          - >-
+            "view": "timeSeries", "stacked": true, "period":300,
+            "stat":"Average", "region":"us-east-1", "title":"EnvironmentHealth"}},
           - >-
             {"type":"metric", "x":0, "y":0, "width":12, "height":6,
             "properties":{"metrics":[[ "AWS/ELB", "HTTPCode_ELB_4XX",


### PR DESCRIPTION
Setup an alarm that will send a notification when an environment
is in a Sever state (25). This will let us know when bridgepf
has stopped working and it will also let us know when bridgepf
failed to deploy to the environment.