### PR TITLE
Remove NEW_RELIC_LOG parameter

### DIFF
--- a/cf_templates/eb_bridgepf.yml
+++ b/cf_templates/eb_bridgepf.yml
@@ -327,9 +327,6 @@ Parameters:
     Type: String
     Default: param_place_holder
     NoEcho: true
-  NewRelicLog:
-    Type: String
-    Default: param_place_holder
   RedisCloudUrl:
     Type: String
     Default: param_place_holder
@@ -509,9 +506,6 @@ Resources:
         - Namespace: 'aws:elasticbeanstalk:application:environment'
           OptionName: NEW_RELIC_LICENSE_KEY
           Value: !Ref NewRelicLicenseKey
-        - Namespace: 'aws:elasticbeanstalk:application:environment'
-          OptionName: NEW_RELIC_LOG
-          Value: !Ref NewRelicLog
         - Namespace: 'aws:elasticbeanstalk:application:environment'
           OptionName: REDISCLOUD_URL
           Value: !Ref RedisCloudUrl

--- a/update_cf_stack.sh
+++ b/update_cf_stack.sh
@@ -68,7 +68,6 @@ ParameterKey=HostPostfix,ParameterValue=-$DNS_HOSTNAME.$DNS_DOMAIN \
 ParameterKey=JavaOpts,ParameterValue='-Dnewrelic.config.file=/var/app/current/newrelic/newrelic.yml -javaagent:/usr/local/lib/newrelic/com.newrelic.agent.java.newrelic-agent.jar' \
 ParameterKey=NewRelicAppName,ParameterValue=$DNS_HOSTNAME \
 ParameterKey=NewRelicLicenseKey,ParameterValue=$NewRelicLicenseKey \
-ParameterKey=NewRelicLog,ParameterValue=stdout \
 ParameterKey=RedisCloudUrl,ParameterValue=$RedisCloudUrl \
 ParameterKey=SnsKey,ParameterValue=$SnsKey \
 ParameterKey=SnsSecretKey,ParameterValue=$SnsSecretKey \


### PR DESCRIPTION
The PR in BridgePF[1] sets up NR apm and infrastructure
logging to files.  With that change we no longer need
NewRelicLog variable.

[1] https://github.com/Sage-Bionetworks/BridgePF/pull/1576