### PR TITLE
Set rolling update deployments to immutable

### DIFF
--- a/cf_templates/eb_bridgepf.yml
+++ b/cf_templates/eb_bridgepf.yml
@@ -387,7 +387,7 @@ Resources:
           Value: true
         - Namespace: 'aws:autoscaling:updatepolicy:rollingupdate'
           OptionName: RollingUpdateType
-          Value: 'Health'
+          Value: 'Immutable'
         - Namespace: 'aws:elasticbeanstalk:application'
           OptionName: Application Healthcheck URL
           Value: !Ref AppHealthcheckUrl


### PR DESCRIPTION
AWS documentation[1] on immutable deployments indicates that it's a good
idea to set both the application and config updates to immutable.

"If you use immutable updates for application version deployments, but
not for configuration, you might encounter an error if you attempt to
deploy an application version that contains configuration changes that
would normally trigger a rolling update (for example, that change
instance type). To avoid this, make the configuration change in a
separate update, or configure immutable updates for both deployments
and configuration changes."

[1] https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/environmentmgmt-updates-immutable.html