### PR TITLE
Update HealthyHostCount graph in dashboard

### DIFF
--- a/cf_templates/eb_bridgepf.yml
+++ b/cf_templates/eb_bridgepf.yml
@@ -1081,10 +1081,10 @@ Resources:
             "properties":{"metrics":[[ "AWS/ELB", "HealthyHostCount",
             "LoadBalancerName","
           - !Ref AwsLoadBalancerName
-          - '", {"stat": "Average"}]],'
+          - '", {"stat": "Maximum"}]],'
           - >-
             "view": "timeSeries", "stacked": true, "period":300,
-            "stat":"Average", "region":"us-east-1", "title":"InstanceHealth"}},
+            "stat":"Maximum", "region":"us-east-1", "title":"HealthyHostCount"}},
           - >-
             {"type":"metric", "x":0, "y":0, "width":12, "height":6,
             "properties":{"metrics":[[ "AWS/ElasticBeanstalk", "EnvironmentHealth",


### PR DESCRIPTION
"InstanceHealth" is a metric provided by enhanced health metric[1]
"HealthyHostCount"[2] is a more appropriate name for this metric.
Also viewing the stat as Maximum makes more sense than average.

[1] https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/health-enhanced-cloudwatch.html
[2] https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/elb-cloudwatch-metrics.html