### PR TITLE
enable travis notifications

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,3 @@
-notifications:
-  email: false
-
 sudo: false
 language: python
 python: 3.4


### PR DESCRIPTION
Travis notifications were disabled during initial CI setup
for this repo.  It's working pretty good now so we should
re-enable it.