### PR TITLE
IT-240: Setup route53 health check

### DIFF
--- a/cf_templates/eb_bridgepf.yml
+++ b/cf_templates/eb_bridgepf.yml
@@ -546,6 +546,15 @@ Resources:
         - !GetAtt
           - AWSEBEnvironment
           - EndpointURL
+  AWSR53HealthCheck:
+    Type: "AWS::Route53::HealthCheck"
+    DependsOn: AWSR53RecordSet
+    Properties:
+      HealthCheckConfig:
+        FullyQualifiedDomainName: !GetAtt AWSEBEnvironment.EndpointURL
+        Port: "443"
+        Type: "HTTPS"
+        ResourcePath: "/?study=api"
   AWSIAMServiceRole:
     Type: 'AWS::IAM::Role'
     Properties:


### PR DESCRIPTION
This sets up route53 health checks for the application endpoint that
elastic beanstalk creates for the environment (bridgepf-develop,
bridgepf-uat, and bridgepf-prod)