### PR TITLE
IT-240: Setup health check status alarm

### DIFF
--- a/cf_templates/eb_bridgepf.yml
+++ b/cf_templates/eb_bridgepf.yml
@@ -964,6 +964,23 @@ Resources:
       Period: 900
       Statistic: Maximum
       Threshold: 25
+  AWSCWHealthCheckStatusAlarm:
+    Type: "AWS::CloudWatch::Alarm"
+    Properties:
+      ActionsEnabled: true
+      AlarmActions:
+        - !Ref AWSSNSTopic
+      ComparisonOperator: LessThanThreshold
+      EvaluationPeriods: 1
+      MetricName: HealthCheckStatus
+      Namespace: AWS/Route53
+      Dimensions:
+        -
+          "Name": "HealthCheckId"
+          "Value": !Ref AWSR53HealthCheck
+      Period: 300
+      Statistic: Average
+      Threshold: 1
   AWSLBSecurityGroup:
     Type: 'AWS::EC2::SecurityGroup'
     Properties:


### PR DESCRIPTION
Setup route53 health check status alarm for bridgepf.  This will send
notifications when elastic beanstalk endpoints go down.