### PR TITLE
Setup policies for BridgePF service user

### DIFF
--- a/cf_templates/eb_bridgepf.yml
+++ b/cf_templates/eb_bridgepf.yml
@@ -1256,6 +1256,41 @@ Resources:
                 - - 'arn:aws:s3:::'
                   - !Ref ConsentsBucket
                   - /*
+  IAMBridgepfECManagedPolicy:
+    Type: 'AWS::IAM::ManagedPolicy'
+    Description: Provide full access to ElastiCache except for delete
+    Properties:
+        PolicyDocument:
+          Version: '2012-10-17'
+          Statement:
+          - Effect: Deny
+            Action:
+              - elasticache:DeleteCacheCluster
+              - elasticache:DeleteCacheParameterGroup
+              - elasticache:DeleteCacheSecurityGroup
+              - elasticache:DeleteCacheSubnetGroup
+              - elasticache:DeleteReplicationGroup
+              - elasticache:DeleteSnapshot
+            Resource: "*"
+          - Effect: Allow
+            Action:
+              - elasticache:*
+            Resource: "*"
+  IAMBridgepfSQSManagedPolicy:
+    Type: 'AWS::IAM::ManagedPolicy'
+    Description: Provide full access to SQA except for create
+    Properties:
+        PolicyDocument:
+          Version: '2012-10-17'
+          Statement:
+          - Effect: Deny
+            Action:
+              - sqs:CreateQueue
+            Resource: "*"
+          - Effect: Allow
+            Action:
+              - sqs:*
+            Resource: "*"
   # App Service User
   AWSIAMBridgepfServiceUserAccessKey:
     Type: 'AWS::IAM::AccessKey'
@@ -1271,3 +1306,9 @@ Resources:
     Properties:
       ManagedPolicyArns:
         - !Ref IAMBridgepfS3ManagedPolicy
+        - arn:aws:iam::aws:policy/AmazonDynamoDBFullAccess
+        - arn:aws:iam::aws:policy/AmazonSNSFullAccess
+        - arn:aws:iam::aws:policy/AmazonSESFullAccess
+        - arn:aws:iam::aws:policy/AmazonRDSFullAccess
+        - !Ref IAMBridgepfECManagedPolicy
+        - !Ref IAMBridgepfSQSManagedPolicy


### PR DESCRIPTION
The Bridge app uses the AWS heroku account to access AWS resources.
The problem is that the heroku account has too much access.  We want
to enforce a least privilege model of access.  This is ongoing work
to setup a user with a reduced set of privileges for BridgePF.

The BridgePF service user group uses many AWS services.  We need to add
additional policies to allow access to those services.

Policies added:
 SQS - full access, except for creating queues
 DDB - full access
 RDS - full access
 SNS - full access
 SES - full access
 EC  - full access, except for deletion