### PR TITLE
Remove HOST_POSTFIX env var

### DIFF
--- a/cf_templates/eb_bridgepf.yml
+++ b/cf_templates/eb_bridgepf.yml
@@ -310,9 +310,6 @@ Parameters:
   HibernateConnectionUsessl:
     Type: String
     Default: param_place_holder
-  HostPostfix:
-    Type: String
-    Default: param_place_holder
   JavaOpts:
     Type: String
     Default: param_place_holder
@@ -516,9 +513,6 @@ Resources:
         - Namespace: 'aws:elasticbeanstalk:application:environment'
           OptionName: HIBERNATE_CONNECTION_USESSL
           Value: !Ref HibernateConnectionUsessl
-        - Namespace: 'aws:elasticbeanstalk:application:environment'
-          OptionName: HOST_POSTFIX
-          Value: !Ref HostPostfix
         - Namespace: 'aws:elasticbeanstalk:application:environment'
           OptionName: JAVA_OPTS
           Value: !Ref JavaOpts

--- a/update_cf_stack.sh
+++ b/update_cf_stack.sh
@@ -70,7 +70,6 @@ ParameterKey=HibernateConnectionPassword,ParameterValue=$HibernateConnectionPass
 ParameterKey=HibernateConnectionUrl,ParameterValue=$HibernateConnectionUrl \
 ParameterKey=HibernateConnectionUsername,ParameterValue=$HibernateConnectionUsername \
 ParameterKey=HibernateConnectionUsessl,ParameterValue=true \
-ParameterKey=HostPostfix,ParameterValue=-$DNS_HOSTNAME.$DNS_DOMAIN \
 ParameterKey=JavaOpts,ParameterValue='-Dnewrelic.config.file=/var/app/current/newrelic/newrelic.yml -javaagent:/usr/local/lib/newrelic/com.newrelic.agent.java.newrelic-agent.jar' \
 ParameterKey=NewRelicAppName,ParameterValue=$DNS_HOSTNAME \
 ParameterKey=NewRelicLicenseKey,ParameterValue=$NewRelicLicenseKey \


### PR DESCRIPTION
The HOST_POSTFIX environment variable is not needed since the
setting is already in bridge-server.conf[1]

[1] https://github.com/Sage-Bionetworks/BridgePF/blob/develop/conf/bridge-server.conf