### PR TITLE
Re-enable 400s, bump 409s threshold

### DIFF
--- a/cf_templates/eb_bridgepf.yml
+++ b/cf_templates/eb_bridgepf.yml
@@ -863,24 +863,22 @@ Resources:
             - '-'
             - - !Ref 'AWS::StackName'
               - 400Count
-# Temporarily commenting out our 400s alarm until the DST bug is fixed.
-# See https://sagebionetworks.jira.com/browse/BRIDGE-1991
-#  AWSCW400Alarm:
-#    Type: "AWS::CloudWatch::Alarm"
-#    Properties:
-#      ActionsEnabled: true
-#      AlarmActions:
-#        - !Ref AWSSNSTopic
-#      ComparisonOperator: GreaterThanOrEqualToThreshold
-#      EvaluationPeriods: 1
-#      MetricName: !Join
-#        - '-'
-#        - - !Ref 'AWS::StackName'
-#          - 400Count
-#      Namespace: LogMetrics/400s
-#      Period: 3600
-#      Statistic: Sum
-#      Threshold: 30
+  AWSCW400Alarm:
+    Type: "AWS::CloudWatch::Alarm"
+    Properties:
+      ActionsEnabled: true
+      AlarmActions:
+        - !Ref AWSSNSTopic
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      EvaluationPeriods: 1
+      MetricName: !Join
+        - '-'
+        - - !Ref 'AWS::StackName'
+          - 400Count
+      Namespace: LogMetrics/400s
+      Period: 3600
+      Statistic: Sum
+      Threshold: 30
   AWSCW403MetricFilter:
     Type: "AWS::Logs::MetricFilter"
     DependsOn: AWSLogsLogGroup
@@ -948,7 +946,7 @@ Resources:
       Namespace: LogMetrics/409s
       Period: 3600
       Statistic: Sum
-      Threshold: 10
+      Threshold: 15
   AWSCW412MetricFilter:
     Type: "AWS::Logs::MetricFilter"
     DependsOn: AWSLogsLogGroup


### PR DESCRIPTION
DST problem has been fixed, so we can re-enable the 400s alarm.

409s current threshold of 10 per hour is very easy to hit and may not be indicative of a widespread error. Bumping up to 15.