### PR TITLE
BRIDGE-1984: remove REDISCLOUD_URL parameter

### DIFF
--- a/cf_templates/eb_bridgepf.yml
+++ b/cf_templates/eb_bridgepf.yml
@@ -529,14 +529,6 @@ Resources:
           OptionName: NEW_RELIC_LICENSE_KEY
           Value: !Ref NewRelicLicenseKey
         - Namespace: 'aws:elasticbeanstalk:application:environment'
-          OptionName: REDISCLOUD_URL
-          Value: !Join
-            - ''
-            - - 'redis://'
-              - !GetAtt AWSECCacheCluster.RedisEndpoint.Address
-              - ':'
-              - !GetAtt AWSECCacheCluster.RedisEndpoint.Port
-        - Namespace: 'aws:elasticbeanstalk:application:environment'
           OptionName: SNS_KEY
           Value: !Ref SnsKey
         - Namespace: 'aws:elasticbeanstalk:application:environment'


### PR DESCRIPTION
Rediscloud migration code was removed[1] so we no longer need the
environment variable.

[1] https://github.com/Sage-Bionetworks/BridgePF/commit/3d2b0f8019b98d22a430ffe4e4463073c3e6ae77