### PR TITLE
BRIDGE-1986: Fix flaky error alarms

### DIFF
--- a/cf_templates/eb_bridgepf.yml
+++ b/cf_templates/eb_bridgepf.yml
@@ -718,6 +718,7 @@ Resources:
       Period: 3600
       Statistic: Sum
       Threshold: 10
+      TreatMissingData: notBreaching
   AWSCWWebErrorMetricFilter:
     Type: "AWS::Logs::MetricFilter"
     DependsOn: AWSLogsLogGroupWebError
@@ -748,6 +749,7 @@ Resources:
       Period: 3600
       Statistic: Sum
       Threshold: 1
+      TreatMissingData: notBreaching
   AWSCWLostMessageMetricFilter:
     Type: "AWS::Logs::MetricFilter"
     DependsOn: AWSLogsLogGroup
@@ -782,6 +784,7 @@ Resources:
       Period: 3600
       Statistic: Sum
       Threshold: 1
+      TreatMissingData: notBreaching
   AWSCWRequestWarningMetricFilter:
     Type: "AWS::Logs::MetricFilter"
     DependsOn: AWSLogsLogGroup
@@ -817,6 +820,7 @@ Resources:
       Period: 3600
       Statistic: Sum
       Threshold: 100
+      TreatMissingData: notBreaching
   AWSCWThroughputExceptionMetricFilter:
     Type: "AWS::Logs::MetricFilter"
     DependsOn: AWSLogsLogGroup
@@ -851,6 +855,7 @@ Resources:
       Period: 3600
       Statistic: Sum
       Threshold: 1
+      TreatMissingData: notBreaching
   AWSCW400MetricFilter:
     Type: "AWS::Logs::MetricFilter"
     DependsOn: AWSLogsLogGroup
@@ -885,6 +890,7 @@ Resources:
       Period: 3600
       Statistic: Sum
       Threshold: 30
+      TreatMissingData: notBreaching
   AWSCW403MetricFilter:
     Type: "AWS::Logs::MetricFilter"
     DependsOn: AWSLogsLogGroup
@@ -919,6 +925,7 @@ Resources:
       Period: 3600
       Statistic: Sum
       Threshold: 10
+      TreatMissingData: notBreaching
   AWSCW409MetricFilter:
     Type: "AWS::Logs::MetricFilter"
     DependsOn: AWSLogsLogGroup
@@ -953,6 +960,7 @@ Resources:
       Period: 3600
       Statistic: Sum
       Threshold: 15
+      TreatMissingData: notBreaching
   AWSCW412MetricFilter:
     Type: "AWS::Logs::MetricFilter"
     DependsOn: AWSLogsLogGroup
@@ -987,6 +995,7 @@ Resources:
       Period: 3600
       Statistic: Sum
       Threshold: 30
+      TreatMissingData: notBreaching
   AWSCWCpuUtilizationAlarm:
     Type: "AWS::CloudWatch::Alarm"
     Properties:


### PR DESCRIPTION
When CloudWatch fires an error alarm, it continues to fire the alarm
several times afterwards, causing alarm flakiness.  AWS documenation[1]
recommends to treat missing data as good so the alarm won't get into this
flakiness state.

[1] https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/AlarmThatSendsEmail.html#alarms-and-missing-data