### PR TITLE
Give service users full s3 access

### DIFF
--- a/cf_templates/eb_bridgepf.yml
+++ b/cf_templates/eb_bridgepf.yml
@@ -1336,6 +1336,7 @@ Resources:
     Type: 'AWS::IAM::Group'
     Properties:
       ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/AmazonS3FullAccess
         - !Ref IAMBridgepfS3ManagedPolicy
         - arn:aws:iam::aws:policy/AmazonDynamoDBFullAccess
         - arn:aws:iam::aws:policy/AmazonSNSFullAccess
@@ -1360,4 +1361,5 @@ Resources:
     Condition: CreateDevResources
     Properties:
       ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/AmazonS3FullAccess
         - !Ref IAMBridgepfLocalS3ManagedPolicy


### PR DESCRIPTION
It's not clear what the exact bucket access should be for a bridgepf
service user so we will give the user AmazonS3FullAccess for now.

Note - Providing AmazonS3FullAccess basically nullifies the
stricter IAMBridgepfS3ManagedPolicy and IAMBridgepfLocalS3ManagedPolicy
policies.  I've decided to just add full access now and leave the cleanup
to a seperate change.