### PR TITLE
BRIDGE-2029: refactor CF deployment

### DIFF
--- a/deploy_infra.sh
+++ b/deploy_infra.sh
@@ -1,12 +1,18 @@
 #!/usr/bin/env bash
 
-# validate cf templates (local)
-echo "Validating cloudformation templates..."
-aws cloudformation validate-template --template-body file://cf_templates/eb_bridgepf.yml
+AWS_ACCOUNT_ID=$(aws sts get-caller-identity --output text --query 'Account')
 
+S3_TARGET_DIR="s3://bridge-cloudformation-artifacts-$AWS_ACCOUNT_ID/$STACK_NAME/"
+echo "Uploading cf_templates to $S3_TARGET_DIR"
+aws s3 cp --recursive cf_templates $S3_TARGET_DIR
+
+TEMPLATE_URL="https://s3.amazonaws.com/bridge-cloudformation-artifacts-$AWS_ACCOUNT_ID/$STACK_NAME/eb_bridgepf.yml"
+echo "Validating CF template $TEMPLATE_URL"
+aws cloudformation validate-template --template-url $TEMPLATE_URL
+
+echo "Deploying CF template $TEMPLATE_URL"
 # Handle message that shouldn't be an error, https://github.com/hashicorp/terraform/issues/5653
-echo "Deploy cloudformation templates..."
-message=$(./update_cf_stack.sh 2>&1 1>/dev/null)
+message=$(./update_cf_stack.sh $TEMPLATE_URL 2>&1 1>/dev/null)
 error_code=$(echo $?)
 if [[ $error_code -ne 0 && $message =~ .*"No updates are to be performed".* ]]; then
   echo "No stack changes detected. An update is not required."

--- a/update_cf_stack.sh
+++ b/update_cf_stack.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+TEMPLATE_URL=$1
+
 # double interpolate vars from travis
 eval export "AppDeployBucket=\$AppDeployBucket_$TRAVIS_BRANCH"
 eval export "AttachmentBucket=\$AttachmentBucket_$TRAVIS_BRANCH"
@@ -37,7 +39,7 @@ eval export "WebservicesUrl=\$WebservicesUrl_$TRAVIS_BRANCH"
 aws cloudformation update-stack \
 --stack-name $STACK_NAME \
 --capabilities CAPABILITY_NAMED_IAM \
---template-body file://cf_templates/eb_bridgepf.yml \
+--template-url $TEMPLATE_URL \
 --parameters \
 ParameterKey=AppDeployBucket,ParameterValue=$AppDeployBucket \
 ParameterKey=AppHealthcheckUrl,ParameterValue='HTTP:80/?study=api' \


### PR DESCRIPTION
Instead of deploying the cloudformation template from a local file
we upload the file to an S3 bucket first then deploy with a reference
to file in the bucket.

Note- The bucket was previously created with CF code[1]

[1] https://github.com/Sage-Bionetworks/Bridge-infra/blob/develop/cf_templates/bridge.yml#L395