### PR TITLE
fix deployment script

### DIFF
--- a/deploy_infra.sh
+++ b/deploy_infra.sh
@@ -12,7 +12,8 @@ aws cloudformation validate-template --template-url $TEMPLATE_URL
 
 echo "Deploying CF template $TEMPLATE_URL"
 # Handle message that shouldn't be an error, https://github.com/hashicorp/terraform/issues/5653
-message=$(./update_cf_stack.sh $TEMPLATE_URL 2>&1 1>/dev/null)
+UPDATE_CMD="./update_cf_stack.sh $TEMPLATE_URL"
+message=$($UPDATE_CMD 2>&1 1>/dev/null)
 error_code=$(echo $?)
 if [[ $error_code -ne 0 && $message =~ .*"No updates are to be performed".* ]]; then
   echo "No stack changes detected. An update is not required."


### PR DESCRIPTION
Can't include the 2> /dev/null inside the quoted string. Quote removal happens
after redirections are processed.

Ref: https://stackoverflow.com/questions/11459100/need-to-redirect-an-output-to-dev-null-works-fine-in-command-line-but-not-i