### PR TITLE
BRIDGE-2038: EB role for BridgePF app

### DIFF
--- a/cf_templates/eb_bridgepf.yml
+++ b/cf_templates/eb_bridgepf.yml
@@ -628,6 +628,14 @@ Resources:
       Path: /
       ManagedPolicyArns:
         - 'arn:aws:iam::aws:policy/AWSElasticBeanstalkWebTier'
+        - 'arn:aws:iam::aws:policy/AmazonS3FullAccess'
+        - !Ref IAMBridgepfS3ManagedPolicy
+        - 'arn:aws:iam::aws:policy/AmazonDynamoDBFullAccess'
+        - 'arn:aws:iam::aws:policy/AmazonSNSFullAccess'
+        - 'arn:aws:iam::aws:policy/AmazonSESFullAccess'
+        - 'arn:aws:iam::aws:policy/AmazonRDSFullAccess'
+        - !Ref IAMBridgepfECManagedPolicy
+        - !Ref IAMBridgepfSQSManagedPolicy
   AWSIAMInstanceProfile:
     Type: 'AWS::IAM::InstanceProfile'
     Properties:
@@ -1214,6 +1222,11 @@ Resources:
                 - ''
                 - - 'arn:aws:s3:::'
                   - !Ref ConsentsBucket
+              - !Join
+                - ''
+                - - 'arn:aws:s3:::'
+                  - 'docs'
+                  - !Ref HostPostfix
           - Sid: ModAccess
             Action:
               - 's3:PutObject'
@@ -1247,6 +1260,12 @@ Resources:
                 - ''
                 - - 'arn:aws:s3:::'
                   - !Ref ConsentsBucket
+                  - /*
+              - !Join
+                - ''
+                - - 'arn:aws:s3:::'
+                  - 'docs'
+                  - !Ref HostPostfix
                   - /*
   # special policy for developer testing
   IAMBridgepfLocalS3ManagedPolicy:


### PR DESCRIPTION
The Bridge app uses AWS heroku access keys to access AWS resources.
The problem with this is that the heroku account is an admin account
and has too much privileges. For a more secure environment we want
to enforce a least privilege model of access.  The better approach
for that is to setup access with roles and instance profiles. This
change is to setup AWS EB role to allow EC2 instances running BridgePF to access
specific AWS resources (s3, ddb, rds, etc..).
  