### PR TITLE
BRIDGE-2057: Setup a RDS security group

### DIFF
--- a/cf_templates/eb_bridgepf.yml
+++ b/cf_templates/eb_bridgepf.yml
@@ -1089,6 +1089,21 @@ Resources:
       NumCacheNodes: '1'
       CacheSecurityGroupNames:
         - !Ref AWSECacheSecurityGroup
+  AWSRdsSecurityGroup:
+    Type: 'AWS::RDS::SecurityGroup'
+    Properties:
+      Description: RDS Security Group
+  AWSRdsSecurityGroupIngress:
+    Type: 'AWS::RDS::SecurityGroupIngress'
+    Properties:
+      DBSecurityGroupName: !Ref AWSRdsSecurityGroup
+      EC2SecurityGroupName: !Join
+        - '-'
+        - - !Ref 'AWS::StackName'
+          - AWSEC2SecurityGroup
+      EC2SecurityGroupOwnerId: !Ref 'AWS::AccountId'
+      # allow access from fred hutch VPN
+      CIDRIP: !ImportValue bridge-FhcrcVpnCidrip
   AWSCWDashboard:
     Type: 'AWS::CloudWatch::Dashboard'
     Properties:


### PR DESCRIPTION
Setup a security group that would only allow access to the Bridge
RDS instance from EC2 instances launch by EB and from within the
fred hutch VPN.

This only adds the security group to AWS it does not apply it to
currently configuredRDS instances.  Since RDS isn't under CF control
applying this security group cannot be automated.