### PR TITLE
Filter blood pressure study from 400s alarm

### DIFF
--- a/cf_templates/eb_bridgepf.yml
+++ b/cf_templates/eb_bridgepf.yml
@@ -856,7 +856,7 @@ Resources:
         - - /aws/elasticbeanstalk
           - !Ref 'AWS::StackName'
           - var/log/web-1.log
-      FilterPattern: '{ $.status = 400 }'
+      FilterPattern: '{ ($.status = 400) && ($.study != "*blood-pressure") }'
       MetricTransformations:
         -
           MetricValue: "1"


### PR DESCRIPTION
Blood Pressure study is generating a lot of 400s due to https://sagebionetworks.jira.com/browse/AA-237. For the short-term, filter Blood Pressure study from the alarm to make it less noisy.