### PR TITLE
BRIDGE-2057: Replace deprecated DB VPC security group.

### DIFF
--- a/cf_templates/eb_bridgepf.yml
+++ b/cf_templates/eb_bridgepf.yml
@@ -1089,20 +1089,24 @@ Resources:
       NumCacheNodes: '1'
       CacheSecurityGroupNames:
         - !Ref AWSECacheSecurityGroup
-  AWSRdsSecurityGroup:
-    Type: 'AWS::RDS::DBSecurityGroup'
+  AWSEC2RdsSecurityGroup:
+    Type: 'AWS::EC2::SecurityGroup'
+    DependsOn: AWSEC2SecurityGroup
     Properties:
-      GroupDescription: RDS Security Group
-      DBSecurityGroupIngress:
-        -
-          EC2SecurityGroupId: !GetAtt AWSEC2SecurityGroup.GroupId
-          EC2SecurityGroupOwnerId: !Ref 'AWS::AccountId'
-  AWSRdsSecurityGroupIngress:
-    Type: 'AWS::RDS::DBSecurityGroupIngress'
-    Properties:
-      DBSecurityGroupName: !Ref AWSRdsSecurityGroup
-      # allow access from fred hutch VPN
-      CIDRIP: !ImportValue bridge-FhcrcVpnCidrip
+      GroupDescription: !Join
+        - '-'
+        - - !Ref 'AWS::StackName'
+          - AWSEC2RdsSecurityGroup
+      VpcId: !Ref AwsDefaultVpcId
+      SecurityGroupIngress:
+        - IpProtocol: tcp
+          FromPort: '3306'
+          ToPort: '3306'
+          SourceSecurityGroupId: !Ref AWSEC2SecurityGroup
+        - CidrIp: !ImportValue bridge-FhcrcVpnCidrip
+          FromPort: '3306'
+          ToPort: '3306'
+          IpProtocol: tcp
   AWSCWDashboard:
     Type: 'AWS::CloudWatch::Dashboard'
     Properties:


### PR DESCRIPTION
"DB VPC security groups have been deprecated"[1] which means they
do not appear in the AWS console and cannot be attached to a DB
instance.  The recommendation is to replace it with an EC2 security
group.

The TCP inbound setting is to allow EC2 instances launch by EB to access
the DB.  The CidrIp inbound setting is to allow connections to the DB from
inside the Fred huch VPN.

[1] https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Overview.RDSSecurityGroups.html