### PR TITLE
BRIDGE-2057: Replace safelist with wide open policy

### DIFF
--- a/cf_templates/eb_bridgepf.yml
+++ b/cf_templates/eb_bridgepf.yml
@@ -1107,20 +1107,19 @@ Resources:
           FromPort: '3306'
           ToPort: '3306'
           IpProtocol: tcp
-        # Tests running on travis requires access to RDS, https://docs.travis-ci.com/user/ip-addresses/
-        - CidrIp: '52.3.55.28/32'
-          FromPort: '3306'
-          ToPort: '3306'
-          IpProtocol: tcp
-        - CidrIp: '34.233.56.198/32'
-          FromPort: '3306'
-          ToPort: '3306'
-          IpProtocol: tcp
-        - CidrIp: '52.54.31.11/32'
-          FromPort: '3306'
-          ToPort: '3306'
-          IpProtocol: tcp
-        - CidrIp: '52.45.185.117/32'
+  # Tests running on travis requires direct access to RDS (should only apply to Dev RDS instance)
+  # https://docs.travis-ci.com/user/ip-addresses/
+  AWSEC2RdsOpenSecurityGroup:
+    Type: 'AWS::EC2::SecurityGroup'
+    DependsOn: AWSEC2SecurityGroup
+    Properties:
+      GroupDescription: !Join
+        - '-'
+        - - !Ref 'AWS::StackName'
+          - AWSEC2RdsOpenSecurityGroup
+      VpcId: !Ref AwsDefaultVpcId
+      SecurityGroupIngress:
+        - CidrIp: '0.0.0.0/0'
           FromPort: '3306'
           ToPort: '3306'
           IpProtocol: tcp


### PR DESCRIPTION
BridgePF tests requires travis sudo and a direct connection to the
dev environment (rds instance). The travis safelist[1] required for sudo
is quite big so the strategy is to apply a wide open DB policy to the Dev RDS
instance instead of adding the entire safelist of IPs to the policy.
This wide open policy should only be applied to the Dev RDS instance.

[1] https://docs.travis-ci.com/user/ip-addresses/