### PR TITLE
Sage VPN user access to bridge DB

### DIFF
--- a/cf_templates/eb_bridgepf.yml
+++ b/cf_templates/eb_bridgepf.yml
@@ -1103,6 +1103,10 @@ Resources:
           FromPort: '3306'
           ToPort: '3306'
           SourceSecurityGroupId: !Ref AWSEC2SecurityGroup
+        - IpProtocol: tcp
+          FromPort: '3306'
+          ToPort: '3306'
+          SourceSecurityGroupId: !ImportValue bridge-VpnSecurityGroup
         - CidrIp: !ImportValue bridge-FhcrcVpnCidrip
           FromPort: '3306'
           ToPort: '3306'


### PR DESCRIPTION
Currently users connected to the FHCRC VPN have direct access to the
bridge database.  This change provides the same access to users
connected to the new Sage VPN. This requires a Bridge-infra PR[1]

[1] https://github.com/Sage-Bionetworks/Bridge-infra/pull/78