### PR TITLE
Fix RDS security group

### DIFF
--- a/cf_templates/eb_bridgepf.yml
+++ b/cf_templates/eb_bridgepf.yml
@@ -1103,10 +1103,6 @@ Resources:
           FromPort: '3306'
           ToPort: '3306'
           SourceSecurityGroupId: !Ref AWSEC2SecurityGroup
-        - IpProtocol: tcp
-          FromPort: '3306'
-          ToPort: '3306'
-          SourceSecurityGroupId: !ImportValue bridge-VpnSecurityGroup
         - CidrIp: !ImportValue bridge-FhcrcVpnCidrip
           FromPort: '3306'
           ToPort: '3306'


### PR DESCRIPTION
The VPN security group should not be added to the RDS security
group.  It should be added directly to the RDS instance which
needs to be done manually.