### PR TITLE
Deprecate access from FHCRC VPN

### DIFF
--- a/cf_templates/eb_bridgepf.yml
+++ b/cf_templates/eb_bridgepf.yml
@@ -1103,10 +1103,6 @@ Resources:
           FromPort: '3306'
           ToPort: '3306'
           SourceSecurityGroupId: !Ref AWSEC2SecurityGroup
-        - CidrIp: !ImportValue bridge-FhcrcVpnCidrip
-          FromPort: '3306'
-          ToPort: '3306'
-          IpProtocol: tcp
   # Tests running on travis requires direct access to RDS (should only apply to Dev RDS instance)
   # https://docs.travis-ci.com/user/ip-addresses/
   AWSEC2RdsOpenSecurityGroup:


### PR DESCRIPTION
Remove access from FHCRC VPN.  Access to private resources, like RDS,
will now be managed by the Sage VPN.  To give users access to a private
resource, like RDS, the VpnSecurityGroup[1] needs to be applied to the
AWS resource and the user needs to be added to the proper user group
in the Sage VPN.

[1] https://github.com/Sage-Bionetworks/Bridge-infra/blob/develop/cf_templates/bridge.yml#L910