### PR TITLE
Extend travis wait time.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,4 +20,4 @@ install:
 script:
 - ./validate-templates.sh || travis_terminate 1
 - ./update_ssm.sh || travis_terminate 1
-- sceptre --var "profile=default" --var "region=us-east-1" launch-env $TRAVIS_BRANCH
+- travis_wait 30 sceptre --var "profile=default" --var "region=us-east-1" launch-env $TRAVIS_BRANCH


### PR DESCRIPTION
Fix timeout because deployment time, particularly for prod env,
can take a while.  Increase travis_wait[1] time from default 10
minutes to 30 minutes.

[1] https://docs.travis-ci.com/user/common-build-problems/#Build-times-out-because-no-output-was-received