### PR TITLE
Patch AWS EC2 AMI and java

### DIFF
--- a/templates/eb_bridgepf.yaml
+++ b/templates/eb_bridgepf.yaml
@@ -367,7 +367,7 @@ Resources:
     Type: 'AWS::ElasticBeanstalk::ConfigurationTemplate'
     Properties:
       ApplicationName: !Ref AWSEBApplication
-      SolutionStackName: 64bit Amazon Linux 2017.03 v2.5.2 running Java 8
+      SolutionStackName: 64bit Amazon Linux 2017.09 v2.6.8 running Java 8
       OptionSettings:
         # EB environment options
         - Namespace: 'aws:autoscaling:asg'


### PR DESCRIPTION
Current version is a year old[1]. Patch to get security updates.

[1] https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/platform-history-javase.html