### PR TITLE
Let CF name the user signed consents bucket

### DIFF
--- a/templates/eb_bridgepf.yaml
+++ b/templates/eb_bridgepf.yaml
@@ -113,10 +113,14 @@ Outputs:
     Value: !Ref UploadCmsPrivBucket
     Export:
       Name: !Sub '${AWS::StackName}-UploadCmsPrivBucket'
-  AWSS3UserSignedConsentsBucket:
+  AWSS3UserSignedConsentsBucket:  # deprecated, replaced with AWSS3UserSignedConsentsDownloadBucket
     Value: !Ref AWSS3UserSignedConsentsBucket
     Export:
       Name: !Sub '${AWS::StackName}-UserSignedConsentsBucket'
+  AWSS3UserSignedConsentsDownloadBucket:
+    Value: !Ref AWSS3UserSignedConsentsDownloadBucket
+    Export:
+      Name: !Sub '${AWS::StackName}-UserSignedConsentsDownloadBucket'
 Parameters:
   AppDeployBucket:
     Type: String
@@ -1480,7 +1484,11 @@ Resources:
           - '/KmsKey'
       TargetKeyId: !Ref AWSKmsKey
   # Buckets for signed consents that users can download
-  AWSS3UserSignedConsentsBucket:
+  AWSS3UserSignedConsentsBucket:  # deprecated, replaced with AWSS3UsersSignedConsentsDownloadBucket
     Type: 'AWS::S3::Bucket'
     Properties:
       BucketName: !Sub '${BridgeEnv}.usersigned.consents.bucket'
+  AWSS3UserSignedConsentsDownloadBucket:
+    Type: 'AWS::S3::Bucket'
+    DeletionPolicy: Retain
+


### PR DESCRIPTION
Giving CF Buckets specific names makes it more difficult to
migrate bridgepf to a separate aws account.  The reason is that
buckets names cannot be duplicated accross aws accounts.  If we
give it a specific name in one account and attempt to run the CF
script again in another account it will fail because CF will
try to give it the new bucket the same name.  The better approach
and one that I've found to be more flexible is to let CF manage
resource names.  We create a bucket letting CF name it then
set parameters in bridge-server.conf with the new bucket name.
We can remove the deprecated bucket after bridgepf app is updated
to reference the new bucket.