### PR TITLE
Refactor elastic cache security group

### DIFF
--- a/config/develop/bridgepf.yaml
+++ b/config/develop/bridgepf.yaml
@@ -45,4 +45,5 @@ parameters:
   UploadBucket: {{ environment_variable.UploadBucket_develop }}
   UploadCmsCertBucket: {{ environment_variable.UploadCmsCertBucket_develop }}
   UploadCmsPrivBucket: {{ environment_variable.UploadCmsPrivBucket_develop }}
+  VpcSubnetIds: subnet-2ec6ee06, subnet-e2197187, subnet-3a47a84d, subnet-9095259c, subnet-133c3455, subnet-42b1d178
   WebservicesUrl: {{ environment_variable.WebservicesUrl_develop }}

--- a/config/prod/bridgepf.yaml
+++ b/config/prod/bridgepf.yaml
@@ -45,4 +45,5 @@ parameters:
   UploadBucket: {{ environment_variable.UploadBucket_prod }}
   UploadCmsCertBucket: {{ environment_variable.UploadCmsCertBucket_prod }}
   UploadCmsPrivBucket: {{ environment_variable.UploadCmsPrivBucket_prod }}
+  VpcSubnetIds: subnet-2ec6ee06, subnet-e2197187, subnet-3a47a84d, subnet-9095259c, subnet-133c3455, subnet-42b1d178
   WebservicesUrl: {{ environment_variable.WebservicesUrl_prod }}

--- a/config/uat/bridgepf.yaml
+++ b/config/uat/bridgepf.yaml
@@ -45,4 +45,5 @@ parameters:
   UploadBucket: {{ environment_variable.UploadBucket_uat }}
   UploadCmsCertBucket: {{ environment_variable.UploadCmsCertBucket_uat }}
   UploadCmsPrivBucket: {{ environment_variable.UploadCmsPrivBucket_uat }}
+  VpcSubnetIds: subnet-2ec6ee06, subnet-e2197187, subnet-3a47a84d, subnet-9095259c, subnet-133c3455, subnet-42b1d178
   WebservicesUrl: {{ environment_variable.WebservicesUrl_uat }}

--- a/templates/eb_bridgepf.yaml
+++ b/templates/eb_bridgepf.yaml
@@ -70,9 +70,9 @@ Outputs:
     Value: !Join
       - ''
       - - 'redis://'
-        - !GetAtt AWSECCacheCluster.RedisEndpoint.Address
+        - !GetAtt AWSElastiCacheCluster.RedisEndpoint.Address
         - ':'
-        - !GetAtt AWSECCacheCluster.RedisEndpoint.Port
+        - !GetAtt AWSElastiCacheCluster.RedisEndpoint.Port
     Export:
       Name: !Sub '${AWS::StackName}-ElastiCacheUrl'
   AWSIAMBridgepfServiceUserAccessKey:
@@ -364,6 +364,9 @@ Parameters:
   UploadCmsPrivBucket:
     Type: String
     Default: param_place_holder
+  VpcSubnetIds:
+    Type: List<AWS::EC2::Subnet::Id>
+    ConstraintDescription: List of VPC subnet IDs (i.e. subnet-1e58fe09, subnet-fb88fe11, ..)
 Conditions:
   CreateDevResources: !Equals [ !Ref BridgeEnv, dev ]
 Resources:
@@ -500,9 +503,9 @@ Resources:
           Value: !Join
             - ''
             - - 'redis://'
-              - !GetAtt AWSECCacheCluster.RedisEndpoint.Address
+              - !GetAtt AWSElastiCacheCluster.RedisEndpoint.Address
               - ':'
-              - !GetAtt AWSECCacheCluster.RedisEndpoint.Port
+              - !GetAtt AWSElastiCacheCluster.RedisEndpoint.Port
         - Namespace: 'aws:elasticbeanstalk:application:environment'
           OptionName: HIBERNATE_CONNECTION_PASSWORD
           Value: !Ref HibernateConnectionPassword
@@ -1073,22 +1076,19 @@ Resources:
           ToPort: '80'
           SourceSecurityGroupId: !Ref AWSLBSecurityGroup
   AWSECacheSecurityGroup:
-    Type: 'AWS::ElastiCache::SecurityGroup'
+    Type: 'AWS::EC2::SecurityGroup'
     Properties:
-      Description: ElastiCache Security Group
-  AWSECacheSecurityGroupIngress:
-    Type: 'AWS::ElastiCache::SecurityGroupIngress'
-    DependsOn:
-      - AWSECacheSecurityGroup
-      - AWSEC2SecurityGroup
-    Properties:
-      CacheSecurityGroupName: !Ref AWSECacheSecurityGroup
-      EC2SecurityGroupName: !Join
+      GroupDescription: !Join
         - '-'
         - - !Ref 'AWS::StackName'
-          - AWSEC2SecurityGroup
-      EC2SecurityGroupOwnerId: !Ref 'AWS::AccountId'
-  AWSECCacheCluster:
+          - AWSECacheSecurityGroup
+      VpcId: !Ref AwsDefaultVpcId
+      SecurityGroupIngress :
+        - IpProtocol : tcp
+          FromPort : '6379'
+          ToPort : '6379'
+          SourceSecurityGroupId: !Ref AWSEC2SecurityGroup
+  AWSECCacheCluster:    # deprecated, replaced with VPC based AWSElastiCacheCluster
     Type: 'AWS::ElastiCache::CacheCluster'
     DependsOn: AWSECacheSecurityGroup
     Properties:
@@ -1097,6 +1097,29 @@ Resources:
       NumCacheNodes: '1'
       CacheSecurityGroupNames:
         - !Ref AWSECacheSecurityGroup
+  AWSECCacheSubnetGroup:
+    Type: "AWS::ElastiCache::SubnetGroup"
+    Properties:
+      Description: !Join
+          - '-'
+          - - !Ref 'AWS::StackName'
+            - AWSECCacheSubnetGroup
+      SubnetIds:
+        - !Select [ 0, !Ref VpcSubnetIds ]
+        - !Select [ 1, !Ref VpcSubnetIds ]
+        - !Select [ 2, !Ref VpcSubnetIds ]
+        - !Select [ 3, !Ref VpcSubnetIds ]
+        - !Select [ 4, !Ref VpcSubnetIds ]
+        - !Select [ 5, !Ref VpcSubnetIds ]
+  AWSElastiCacheCluster:
+    Type: 'AWS::ElastiCache::CacheCluster'
+    Properties:
+      Engine: redis
+      CacheNodeType: !Ref ElastiCacheInstanceType
+      NumCacheNodes: '1'
+      VpcSecurityGroupIds:
+        - !GetAtt AWSECacheSecurityGroup.GroupId
+      CacheSubnetGroupName: !Ref AWSECCacheSubnetGroup
   AWSEC2RdsSecurityGroup:
     Type: 'AWS::EC2::SecurityGroup'
     DependsOn: AWSEC2SecurityGroup


### PR DESCRIPTION
Apparently using 'AWS::ElastiCache::SecurityGroup' will not put
ElastiCache in a VPC.  It is recommended to create the security
group with 'AWS::EC2::SecurityGroup' instead. from the docs..

  "To create an ElastiCache cluster in a VPC, use the
  AWS::EC2::SecurityGroup resource."

There's also a bug with using 'AWS::ElastiCache::SecurityGroup'
in that CF fails to honor dependencies on this resource which may
cause errors like this..

  "AWS::ElastiCache::SecurityGroupIngress    AWSECacheSecurityGroupIngress
  The provided security group sg-ca0f6982 does not exist"

[1] https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-elasticache-security-group.html