### PR TITLE
Fix build error for AWSECacheSecurityGroup

### DIFF
--- a/templates/eb_bridgepf.yaml
+++ b/templates/eb_bridgepf.yaml
@@ -1075,13 +1075,17 @@ Resources:
           FromPort: '80'
           ToPort: '80'
           SourceSecurityGroupId: !Ref AWSLBSecurityGroup
-  AWSECacheSecurityGroup:
+  AWSECacheSecurityGroup:   # deprecated, replaced with VPC based AWSElastiCacheSecurityGroup
+    Type: 'AWS::ElastiCache::SecurityGroup'
+    Properties:
+      Description: ElastiCache Security Group
+  AWSElastiCacheSecurityGroup:
     Type: 'AWS::EC2::SecurityGroup'
     Properties:
       GroupDescription: !Join
         - '-'
         - - !Ref 'AWS::StackName'
-          - AWSECacheSecurityGroup
+          - AWSElastiCacheSecurityGroup
       VpcId: !Ref AwsDefaultVpcId
       SecurityGroupIngress :
         - IpProtocol : tcp
@@ -1090,13 +1094,13 @@ Resources:
           SourceSecurityGroupId: !Ref AWSEC2SecurityGroup
   AWSECCacheCluster:    # deprecated, replaced with VPC based AWSElastiCacheCluster
     Type: 'AWS::ElastiCache::CacheCluster'
-    DependsOn: AWSECacheSecurityGroup
+    DependsOn: AWSElastiCacheSecurityGroup
     Properties:
       Engine: redis
       CacheNodeType: !Ref ElastiCacheInstanceType
       NumCacheNodes: '1'
       CacheSecurityGroupNames:
-        - !Ref AWSECacheSecurityGroup
+        - !Ref AWSElastiCacheSecurityGroup
   AWSECCacheSubnetGroup:
     Type: "AWS::ElastiCache::SubnetGroup"
     Properties:
@@ -1118,7 +1122,7 @@ Resources:
       CacheNodeType: !Ref ElastiCacheInstanceType
       NumCacheNodes: '1'
       VpcSecurityGroupIds:
-        - !GetAtt AWSECacheSecurityGroup.GroupId
+        - !GetAtt AWSElastiCacheSecurityGroup.GroupId
       CacheSubnetGroupName: !Ref AWSECCacheSubnetGroup
   AWSEC2RdsSecurityGroup:
     Type: 'AWS::EC2::SecurityGroup'


### PR DESCRIPTION
CF does not allow changing the resource type on an existin resource.
We need to make a new resource then deprecate the old one.

Fix this error...

  "error occurred (ValidationError) when calling the UpdateStack operation:
   Update of resource type is not permitted. The new template modifies
   resource type of the following resources: [AWSECacheSecurityGroup]"