### PR TITLE
Patch EB platform

### DIFF
--- a/templates/eb_bridgepf.yaml
+++ b/templates/eb_bridgepf.yaml
@@ -374,7 +374,7 @@ Resources:
     Type: 'AWS::ElasticBeanstalk::ConfigurationTemplate'
     Properties:
       ApplicationName: !Ref AWSEBApplication
-      SolutionStackName: 64bit Amazon Linux 2017.09 v2.6.8 running Java 8
+      SolutionStackName: 64bit Amazon Linux 2018.03 v2.7.1 running Java 8
       OptionSettings:
         # EB environment options
         - Namespace: 'aws:autoscaling:asg'


### PR DESCRIPTION
AWS just dropped support for "64bit Amazon Linux 2017.09 v2.6.8 running Java 8"
so we need to update to next supported version.

[1] https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/concepts.platforms.html#concepts.platforms.javase