### PR TITLE
Give CF service role access to KMS keys

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,5 +19,5 @@ install:
 - pip install sceptre
 script:
 - ./validate-templates.sh || travis_terminate 1
-- ./update_ssm.sh || travis_terminate 1
+# - ./update_ssm.sh || travis_terminate 1
 - travis_wait 45 sceptre --var "profile=default" --var "region=us-east-1" launch-env $TRAVIS_BRANCH

--- a/templates/eb_bridgepf.yaml
+++ b/templates/eb_bridgepf.yaml
@@ -1463,12 +1463,7 @@ Resources:
             Effect: "Allow"
             Principal:
               AWS:
-                - !Join
-                  - ''
-                  - - 'arn:aws:iam::'
-                    - !Ref AWS::AccountId
-                    - ':user/'
-                    - !ImportValue us-east-1-bootstrap-TravisUser
+                - !ImportValue us-east-1-bootstrap-CfServiceRoleArn
             Action:
               - "kms:Create*"
               - "kms:Describe*"
@@ -1488,12 +1483,7 @@ Resources:
             Effect: "Allow"
             Principal:
               AWS:
-                - !Join
-                  - ''
-                  - - 'arn:aws:iam::'
-                    - !Ref AWS::AccountId
-                    - ':user/'
-                    - !ImportValue us-east-1-bootstrap-TravisUser
+                - !ImportValue us-east-1-bootstrap-CfServiceRoleArn
                 - !GetAtt AWSIAMBridgepfServiceUser.Arn
             Action:
               - "kms:Encrypt"


### PR DESCRIPTION
Since KMS key management must be done using CF service role change
permission to allow that role access.

Note: temporarily disable key updates.