### PR TITLE
 set channel throttle timeout back to 300 seconds 

### DIFF
--- a/config/develop/bridgepf.yaml
+++ b/config/develop/bridgepf.yaml
@@ -24,7 +24,7 @@ parameters:
   BridgeEnv: dev
   BridgeHealthcodeRedisKey: !ssm /bridgepf-develop/BridgeHealthcodeRedisKey
   BridgeUser: heroku
-  ChannelThrottleTimeoutSeconds: '10'
+  ChannelThrottleTimeoutSeconds: '300'
   ConsentsBucket: org-sagebridge-consents-dev
   DNSHostname: bridgepf-develop
   DNSDomain: sagebridge.org

--- a/config/develop/bridgepf.yaml
+++ b/config/develop/bridgepf.yaml
@@ -24,6 +24,7 @@ parameters:
   BridgeEnv: dev
   BridgeHealthcodeRedisKey: !ssm /bridgepf-develop/BridgeHealthcodeRedisKey
   BridgeUser: heroku
+  ChannelThrottleTimeoutSeconds: 10
   ConsentsBucket: org-sagebridge-consents-dev
   DNSHostname: bridgepf-develop
   DNSDomain: sagebridge.org

--- a/config/prod/bridgepf.yaml
+++ b/config/prod/bridgepf.yaml
@@ -24,7 +24,7 @@ parameters:
   BridgeEnv: prod
   BridgeHealthcodeRedisKey: !ssm /bridgepf-prod/BridgeHealthcodeRedisKey
   BridgeUser: heroku
-  ChannelThrottleTimeoutSeconds: '10'
+  ChannelThrottleTimeoutSeconds: '300'
   ConsentsBucket: org-sagebridge-consents-prod
   DNSHostname: bridgepf-prod
   DNSDomain: sagebridge.org

--- a/config/prod/bridgepf.yaml
+++ b/config/prod/bridgepf.yaml
@@ -24,6 +24,7 @@ parameters:
   BridgeEnv: prod
   BridgeHealthcodeRedisKey: !ssm /bridgepf-prod/BridgeHealthcodeRedisKey
   BridgeUser: heroku
+  ChannelThrottleTimeoutSeconds: 10
   ConsentsBucket: org-sagebridge-consents-prod
   DNSHostname: bridgepf-prod
   DNSDomain: sagebridge.org

--- a/config/uat/bridgepf.yaml
+++ b/config/uat/bridgepf.yaml
@@ -24,6 +24,7 @@ parameters:
   BridgeEnv: uat
   BridgeHealthcodeRedisKey: !ssm /bridgepf-uat/BridgeHealthcodeRedisKey
   BridgeUser: heroku
+  ChannelThrottleTimeoutSeconds: 10
   ConsentsBucket: org-sagebridge-consents-uat
   DNSHostname: bridgepf-uat
   DNSDomain: sagebridge.org

--- a/config/uat/bridgepf.yaml
+++ b/config/uat/bridgepf.yaml
@@ -24,7 +24,7 @@ parameters:
   BridgeEnv: uat
   BridgeHealthcodeRedisKey: !ssm /bridgepf-uat/BridgeHealthcodeRedisKey
   BridgeUser: heroku
-  ChannelThrottleTimeoutSeconds: '10'
+  ChannelThrottleTimeoutSeconds: '300'
   ConsentsBucket: org-sagebridge-consents-uat
   DNSHostname: bridgepf-uat
   DNSDomain: sagebridge.org

--- a/templates/eb_bridgepf.yaml
+++ b/templates/eb_bridgepf.yaml
@@ -175,6 +175,9 @@ Parameters:
   BridgeUser:
     Type: String
     Default: param_place_holder
+  ChannelThrottleTimeoutSeconds:
+    Type: String
+    Default: param_place_holder
   DNSDomain:
     Type: String
     Description: DNS Domain name for deployment
@@ -477,6 +480,9 @@ Resources:
         - Namespace: 'aws:elasticbeanstalk:application:environment'
           OptionName: BRIDGEPF_SERVICE_USER_SECRET_KEY
           Value: !GetAtt AWSIAMBridgepfServiceUserAccessKey.SecretAccessKey
+        - Namespace: 'aws:elasticbeanstalk:application:environment'
+          OptionName: CHANNEL_THROTTLE_TIMEOUT_SECONDS
+          Value: !Ref ChannelThrottleTimeoutSeconds
         - Namespace: 'aws:elasticbeanstalk:application:environment'
           OptionName: DOMAIN
           Value: !Ref Domain


### PR DESCRIPTION
https://github.com/Sage-Bionetworks/BridgePF/pull/1769 must be merged before we merge this.

Now that we have a check to disable throttling for phone sign-in, we should set the throttling for email sign-in back to what it was before.