### PR TITLE
[BRIDGE-1950] give EB role access to SSM and KMS

### DIFF
--- a/templates/eb_bridgepf.yaml
+++ b/templates/eb_bridgepf.yaml
@@ -618,6 +618,7 @@ Resources:
       ManagedPolicyArns:
         - 'arn:aws:iam::aws:policy/service-role/AWSElasticBeanstalkEnhancedHealth'
         - 'arn:aws:iam::aws:policy/service-role/AWSElasticBeanstalkService'
+        - 'arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM'
   AWSIAMRole:
     Type: 'AWS::IAM::Role'
     Properties:
@@ -1482,6 +1483,7 @@ Resources:
                     - ':root'
                 - !ImportValue us-east-1-bootstrap-CfServiceRoleArn
                 - !GetAtt AWSIAMBridgepfServiceUser.Arn
+                - !GetAtt AWSIAMServiceRole.Arn
             Action:
               - "kms:Encrypt"
               - "kms:Decrypt"


### PR DESCRIPTION
We store secrets for bridge app in the AWS SSM (parameter store).
Giving the EB role running bridgepf app access to the SSM and KMS key
will allow the bridge app to access the secrets without having to
provide any credentials at all.