### PR TITLE
increase prod hosts size and type

### DIFF
--- a/config/prod/bridgepf.yaml
+++ b/config/prod/bridgepf.yaml
@@ -6,7 +6,7 @@ parameters:
   AttachmentBucket: org-sagebridge-attachment-prod
   AwsAutoScalingGroupName: awseb-e-693tmvruhq-stack-AWSEBAutoScalingGroup-ZUQRSM8OL33O
   AwsAutoScalingMaxSize: "6"
-  AwsAutoScalingMinSize: "3"
+  AwsAutoScalingMinSize: "6"
   AwsDefaultVpcId: vpc-9c70bbf9
   AwsEbHealthReportingSystem: enhanced
   AwsKey: !ssm /bridgepf-prod/AwsKey
@@ -29,7 +29,7 @@ parameters:
   DNSHostname: bridgepf-prod
   DNSDomain: sagebridge.org
   Domain: ws.sagebridge.org
-  EC2InstanceType: t2.small
+  EC2InstanceType: t3.medium
   ElastiCacheInstanceType:  cache.t2.micro
   EmailUnsubscribeToken: !ssm /bridgepf-prod/EmailUnsubscribeToken
   HibernateConnectionPassword: !ssm /bridgepf-prod/HibernateConnectionPassword

--- a/config/prod/bridgepf.yaml
+++ b/config/prod/bridgepf.yaml
@@ -5,8 +5,8 @@ parameters:
   AppHealthcheckUrl: 'HTTP:80/?study=api'
   AttachmentBucket: org-sagebridge-attachment-prod
   AwsAutoScalingGroupName: awseb-e-693tmvruhq-stack-AWSEBAutoScalingGroup-ZUQRSM8OL33O
-  AwsAutoScalingMaxSize: "6"
-  AwsAutoScalingMinSize: "6"
+  AwsAutoScalingMaxSize: "9"
+  AwsAutoScalingMinSize: "9"
   AwsDefaultVpcId: vpc-9c70bbf9
   AwsEbHealthReportingSystem: enhanced
   AwsKey: !ssm /bridgepf-prod/AwsKey


### PR DESCRIPTION
BP Lab redrives is currently spiking production and putting it into an unhealthy state. We're increasing prod instance types from t2.small to t3.medium, and setting the min hosts to 6 so we always have 6 hosts.

We will decrease the number and type of hosts after the redrive is complete (~mid October) and revisit auto-scaling.