### PR TITLE
Reduce prod hosts from 9 to 3

### DIFF
--- a/config/prod/bridgepf.yaml
+++ b/config/prod/bridgepf.yaml
@@ -5,8 +5,8 @@ parameters:
   AppHealthcheckUrl: 'HTTP:80/?study=api'
   AttachmentBucket: org-sagebridge-attachment-prod
   AwsAutoScalingGroupName: awseb-e-693tmvruhq-stack-AWSEBAutoScalingGroup-ZUQRSM8OL33O
-  AwsAutoScalingMaxSize: "9"
-  AwsAutoScalingMinSize: "9"
+  AwsAutoScalingMaxSize: "3"
+  AwsAutoScalingMinSize: "3"
   AwsDefaultVpcId: vpc-9c70bbf9
   AwsEbHealthReportingSystem: enhanced
   AwsKey: !ssm /bridgepf-prod/AwsKey


### PR DESCRIPTION
We had previously increased from 3-6 t2.smalls to 9 t3.mediums, in order to support some heavy redrives for BP Lab.

Now that that's done, we have no need of all this extra capacity. Reducing down to 3 t3.mediums.