### PR TITLE
Suppress Netty errors from our ERROR alarm

### DIFF
--- a/templates/eb_bridgepf.yaml
+++ b/templates/eb_bridgepf.yaml
@@ -695,7 +695,8 @@ Resources:
                       - "StatusLogger No log4j2 configuration file found"
                       - "StrictValidationHandler.handleErrors"
                       - "Strict upload validation error"
-                      - org.hibernate'
+                      - org.hibernate
+                      - play.core.server.netty.PlayDefaultUpstreamHandler'
       MetricTransformations:
         -
           MetricValue: "1"


### PR DESCRIPTION
The Netty errors are not actionable and are basically just noise. Suppressing them from the alarm.