### PR TITLE
Disable alarms for M2C2

### DIFF
--- a/templates/eb_bridgepf.yaml
+++ b/templates/eb_bridgepf.yaml
@@ -868,7 +868,7 @@ Resources:
         - - /aws/elasticbeanstalk
           - !Ref 'AWS::StackName'
           - var/log/web-1.log
-      FilterPattern: '{ $.status = 400 }'
+      FilterPattern: '{ ($.status = 400) && ($.study != "psu-m2c2") }'
       MetricTransformations:
         -
           MetricValue: "1"
@@ -903,7 +903,7 @@ Resources:
         - - /aws/elasticbeanstalk
           - !Ref 'AWS::StackName'
           - var/log/web-1.log
-      FilterPattern: '{ $.status = 403 }'
+      FilterPattern: '{ ($.status = 403) && ($.study != "psu-m2c2") }'
       MetricTransformations:
         -
           MetricValue: "1"
@@ -938,7 +938,7 @@ Resources:
         - - /aws/elasticbeanstalk
           - !Ref 'AWS::StackName'
           - var/log/web-1.log
-      FilterPattern: '{ $.status = 409 }'
+      FilterPattern: '{ ($.status = 409) && ($.study != "psu-m2c2") }'
       MetricTransformations:
         -
           MetricValue: "1"
@@ -973,7 +973,7 @@ Resources:
         - - /aws/elasticbeanstalk
           - !Ref 'AWS::StackName'
           - var/log/web-1.log
-      FilterPattern: '{( $.status = 412 ) && ( $.uri != "*/signIn*" ) && ( $.uri != "*/verifyEmail*" ) }'
+      FilterPattern: '{( $.status = 412 ) && ( $.uri != "*/signIn*" ) && ( $.uri != "*/verifyEmail*" ) && ($.study != "psu-m2c2") }'
       MetricTransformations:
         -
           MetricValue: "1"


### PR DESCRIPTION
M2C2 is currently in development, and in the process, is setting off a lot of alarms. Disabling the alarms specifically for M2C2.

Note that signUps, request channel signIns, and failed signIn requests won't log study ID until https://github.com/Sage-Bionetworks/BridgePF/pull/1816 is pushed to Prod.