### PR TITLE
Disable 412s alarm for BP Lab

### DIFF
--- a/templates/eb_bridgepf.yaml
+++ b/templates/eb_bridgepf.yaml
@@ -979,7 +979,7 @@ Resources:
         - - /aws/elasticbeanstalk
           - !Ref 'AWS::StackName'
           - var/log/web-1.log
-      FilterPattern: '{( $.status = 412 ) && ( $.uri != "*/signIn*" ) && ( $.uri != "*/verifyEmail*" ) && ($.study != "psu-m2c2") }'
+      FilterPattern: '{( $.status = 412 ) && ( $.uri != "*/signIn*" ) && ( $.uri != "*/verifyEmail*" ) && ($.study != "psu-m2c2")  && ($.study != "samsung-blood-pressure") }'
       MetricTransformations:
         -
           MetricValue: "1"


### PR DESCRIPTION
BP Lab is coded in a way such that upgrading users can generate a ton of 412s before they submit reconsent. This means that the alarm is effectively useless for detecting consent issues. Disabling the alarm so that it doesn't fire sporadically.