### PR TITLE
suppressing BP Lab from 409s

### DIFF
--- a/templates/eb_bridgepf.yaml
+++ b/templates/eb_bridgepf.yaml
@@ -944,7 +944,7 @@ Resources:
         - - /aws/elasticbeanstalk
           - !Ref 'AWS::StackName'
           - var/log/web-1.log
-      FilterPattern: '{ ($.status = 409) && ($.study != "psu-m2c2") }'
+      FilterPattern: '{ ($.status = 409) && ($.study != "psu-m2c2") && ($.study != "samsung-blood-pressure") }'
       MetricTransformations:
         -
           MetricValue: "1"


### PR DESCRIPTION
There's a constant stream of these coming from BP Lab (see https://sagebionetworks.jira.com/browse/AABP-854). Suppressing BP Lab from 409s so we don't have spurious alarms.